### PR TITLE
Remove implicit defs

### DIFF
--- a/src/main/scala/com/ironcorelabs/davenport/DB.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/DB.scala
@@ -25,23 +25,16 @@ object DB {
 
   // 3. Implicit lift required for Coyoneda shortcuts and other lift shortcuts
   implicit val MonadDBOps: Monad[DBOps] = Free.freeMonad[({ type l[a] = Coyoneda[DBOp, a] })#l]
-  // implicit val MonoidThrowable: Monoid[Throwable] = {
-  // def zero = ???
-  // def append(f1: Throwable, f2: => Throwable) = ???
-  // }
-  // implicit val EachDBOps: Each[DBOps] = new Each[DBOps] {
-  // def each[A](fa: DBOps[A])(f: A => Unit) = fa foreach f
-  // }
+  def liftIntoDBProg[A](opt: Option[A]): DBProg[A] = EitherT.eitherT(Monad[DBOps].point(opt \/> new Exception("Value not found")))
+  def liftIntoDBProg[A](either: Throwable \/ A): DBProg[A] = EitherT.eitherT(Monad[DBOps].point(either))
   def liftIntoDBProg[A](opt: Option[A], errormessage: String): DBProg[A] = EitherT.eitherT(Monad[DBOps].point(opt \/> new Exception(errormessage)))
-  implicit def liftIntoDBProg[A](opt: Option[A]): DBProg[A] = EitherT.eitherT(Monad[DBOps].point(opt \/> new Exception("Value not found")))
-  implicit def liftIntoDBProg[A](either: Throwable \/ A): DBProg[A] = EitherT.eitherT(Monad[DBOps].point(either))
-  implicit def liftToFreeEitherT[A](a: DBOp[Throwable \/ A]): DBProg[A] = {
+  def liftToFreeEitherT[A](a: DBOp[Throwable \/ A]): DBProg[A] = {
     val free: DBOps[Throwable \/ A] = Free.liftFC(a)
     EitherT.eitherT(free)
   }
-  implicit def dbProgFail[A](e: Throwable): DBProg[A] = liftIntoDBProg(e.left)
-  implicit def key2String(k: Key): String = k.value
-  implicit def string2Key(s: String): Key = Key(s)
+  def dbProgFail[A](e: Throwable): DBProg[A] = liftIntoDBProg(e.left)
+  def key2String(k: Key): String = k.value
+  def string2Key(s: String): Key = Key(s)
 
   // 4. Algebraic Data Type of DB operations. (A persistence grammar of sorts.)
   sealed trait DBOp[+A]
@@ -53,7 +46,7 @@ object DB {
   case class IncrementCounter(key: Key, delta: Long = 1) extends DBOp[Throwable \/ Long]
   case class BatchCreateDocs(st: DBBatchStream, continue: Throwable => Boolean) extends DBOp[Throwable \/ DBBatchResults]
 
-  // 5. Convenience functions lifting DBOp to EitherT[Free[Throwable \/ DBOp]]
+  // 5. Convenience functions lifting DBOp to EitherT[Free, Throwable,DBOp]
   def getDoc(k: Key): DBProg[DbValue] = liftToFreeEitherT(GetDoc(k))
   def createDoc(k: Key, doc: RawJsonString): DBProg[DbValue] =
     liftToFreeEitherT(CreateDoc(k, doc))

--- a/src/main/scala/com/ironcorelabs/davenport/DBDocument.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/DBDocument.scala
@@ -23,7 +23,7 @@ import argonaut._, Argonaut._
 
 import DB._
 
-abstract trait DBDocument[T] {
+trait DBDocument[T] {
   val key: Key
   val data: T
   val cas: Long

--- a/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
@@ -12,7 +12,6 @@ import DisjunctionValues._
 import scala.language.postfixOps
 import DB._
 import com.ironcorelabs.davenport.tags.RequiresCouch
-// import com.ironcorelabs.davenport.tagobjects.RequiresCouch
 import scala.concurrent.duration._
 
 @RequiresCouch


### PR DESCRIPTION
- These defs aren't being used as implicits. I've found implicit defs that do type conversions as a bit scary because it can lead to code that looks like it returns one type, but it doesn't.
- Also deleted a few rogue comments.