### PR TITLE
Use Scalaz.stream for batch imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   "io.reactivex" %% "rxscala" % "0.25.0", // to better work with the couchbase java client
   //"org.slf4j" % "slf4j-nop" % "1.6.4", // logging fun
   "io.argonaut" %% "argonaut" % "6.1", // json (de)serialization scalaz style
-  "oncue.knobs" %% "core" % "3.3.0" // for config happiness
+  "oncue.knobs" %% "core" % "3.3.0", // for config happiness
+  "org.scalaz.stream" %% "scalaz-stream" % "0.7.2a"
 )
 
 // Test

--- a/src/main/scala/com/ironcorelabs/davenport/DB.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/DB.scala
@@ -7,6 +7,8 @@ package com.ironcorelabs.davenport
 
 import scalaz._, Scalaz._, scalaz.concurrent.Task
 import scala.language.implicitConversions
+import scalaz.stream.Process
+import scala.language.higherKinds
 
 /**
  * Contains the primitives for building DBProg programs for later execution by
@@ -59,23 +61,6 @@ object DB {
    *  `MemConnection.exec`, these are executed.
    */
   type DBProg[A] = EitherT[DBOps, Throwable, A]
-
-  /**
-   * A batch error gives a record number and an error string
-   *
-   *  When importing a lot of data, this will store accrued errors
-   *  indicating their source.
-   */
-  final case class DbBatchError(recordNum: Int, error: Throwable)
-
-  /**
-   * Makes use of `scalaz.These` (`\&/`) to accumulate successes and failures
-   *
-   *  `\&/.This` will capture a list of encountered errors and their line nums
-   *
-   *  `\&/.That` will capture a list of successfully imported line nums
-   */
-  type DBBatchResults = (IList[DbBatchError] \&/ IList[Int])
 
   /**
    * Transform incoming data into this type
@@ -138,9 +123,6 @@ object DB {
     EitherT.eitherT(free)
   }
 
-  /** Convenience for converting an exception into a [[DBProg]] operation */
-  def dbProgFail[A](e: Throwable): DBProg[A] = liftIntoDBProg(e.left)
-
   //
   //
   // 4. Algebraic Data Type of DB operations. (A persistence grammar of sorts.)
@@ -155,7 +137,6 @@ object DB {
   case class RemoveKey(key: Key) extends DBOp[Throwable \/ Unit]
   case class GetCounter(key: Key) extends DBOp[Throwable \/ Long]
   case class IncrementCounter(key: Key, delta: Long = 1) extends DBOp[Throwable \/ Long]
-  case class BatchCreateDocs(st: DBBatchStream, continue: Throwable => Boolean) extends DBOp[Throwable \/ DBBatchResults]
 
   //
   //
@@ -185,18 +166,6 @@ object DB {
     liftToFreeEitherT(IncrementCounter(k, delta))
 
   /**
-   * Process a stream of records into new database documents
-   *
-   *  Pass in a continue function to control what happens on error. For example,
-   *  if you want to abort imports on certain errors or after a certain number
-   *  of errors, use a custom `continue` function. By default, the processing of
-   *  the incoming records does not stop until the end of the records are
-   *  reached.
-   */
-  def batchCreateDocs(st: DBBatchStream, continue: Throwable => Boolean = _ => true): DBProg[DBBatchResults] =
-    liftToFreeEitherT(BatchCreateDocs(st, continue))
-
-  /**
    * Convenience function to fetch a doc and transform it via a function `f`
    *
    *  In practice, this is more an example showing how to build a function like
@@ -208,15 +177,17 @@ object DB {
     res <- updateDoc(k, f(t.jsonString), t.hashVer)
   } yield res
 
-  //
-  // Other type conveniences
-  //
-
-  /** Generate a [[DBBatchResults]] error */
-  def batchFailed(idx: Int, e: Throwable): DBBatchResults =
-    IList(DbBatchError(idx, e)).wrapThis[IList[Int]]
-
-  /** Generate a [[DBBatchResults]] success */
-  def batchSucceeded(idx: Int): DBBatchResults =
-    IList(idx).wrapThat[IList[DbBatchError]]
+  /**
+   * Object that contains batch operations for DB. They have been separated out because they cannot be mixed with `DBProg` operations
+   * without first lifting them into a process via `liftToProcess`.
+   */
+  object batch {
+    def liftToProcess[A](prog: DBProg[A]): Process[DBOps, Throwable \/ A] = Process.eval(prog.run)
+    /**
+     * Create all values in the Foldable F.
+     */
+    def batchCreateDocs[F[_]](foldable: F[(Key, RawJsonString)])(implicit F: Foldable[F]): Process[DBOps, Throwable \/ DbValue] = {
+      Process.emitAll(foldable.toList).evalMap { case (key, json) => createDoc(key, json).run }
+    }
+  }
 }

--- a/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
@@ -129,7 +129,7 @@ class CouchConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll 
       res.value should ===(10L)
     }
     "be happy doing initial batch import" in {
-      val res = CouchConnection.translateProcess(createDocs(tenrows)).runLog.attemptRun.value
+      val res: IndexedSeq[Throwable \/ DbValue] = CouchConnection.translateProcess(createDocs(tenrows)).runLog.attemptRun.value
       val (lefts, rights) = res.toList.separate
       lefts.length should ===(0)
       rights.length should ===(tenrows.length)
@@ -137,8 +137,7 @@ class CouchConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll 
     }
     "error on single create after batch" in {
       val res = CouchConnection.execTask(tenrows.map { case (key, value) => createDoc(key, value) }.head).attemptRun.value
-      res.leftValue
-      ()
+      res should be(left)
     }
 
     "return errors batch importing the same items again" in {

--- a/src/test/scala/com/ironcorelabs/davenport/DBDocumentSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/DBDocumentSpec.scala
@@ -45,7 +45,7 @@ class DBDocumentSpec extends WordSpec with Matchers with DisjunctionMatchers wit
     "create, then get and then remove wrapper docs" in {
       val create = DBUser.create(u1)
       val (data, res) = MemConnection.run(create)
-
+      res should be(right)
       // next line is basically to make sure hashver is populated and juice up
       // code coverage
       res.value.hashver.value should be > 0L
@@ -54,6 +54,7 @@ class DBDocumentSpec extends WordSpec with Matchers with DisjunctionMatchers wit
       val (data2, res2) = MemConnection.run(get, data)
       res2.value.data should equal(u1)
       val (data3, res3) = MemConnection.run(res2.value.remove, data)
+      res3 should be(right)
     }
     "attempt removal of a missing doc" in {
       MemConnection(DBUser.remove(k1)) should be(left) // fail since doesn't exist

--- a/src/test/scala/com/ironcorelabs/davenport/DBDocumentSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/DBDocumentSpec.scala
@@ -45,7 +45,6 @@ class DBDocumentSpec extends WordSpec with Matchers with DisjunctionMatchers wit
     "create, then get and then remove wrapper docs" in {
       val create = DBUser.create(u1)
       val (data, res) = MemConnection.run(create)
-      res should be(right)
 
       // next line is basically to make sure hashver is populated and juice up
       // code coverage
@@ -55,7 +54,6 @@ class DBDocumentSpec extends WordSpec with Matchers with DisjunctionMatchers wit
       val (data2, res2) = MemConnection.run(get, data)
       res2.value.data should equal(u1)
       val (data3, res3) = MemConnection.run(res2.value.remove, data)
-      res3 should be(right)
     }
     "attempt removal of a missing doc" in {
       MemConnection(DBUser.remove(k1)) should be(left) // fail since doesn't exist

--- a/src/test/scala/com/ironcorelabs/davenport/DBSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/DBSpec.scala
@@ -16,8 +16,5 @@ class DBSpec extends WordSpec with Matchers with BeforeAndAfterAll with Disjunct
     "fail lifting none into dbprog" in {
       MemConnection(liftIntoDBProg(None)) should be(left)
     }
-    "fail using DBProgFail" in {
-      MemConnection(dbProgFail(new Exception("boom"))) should be(left)
-    }
   }
 }

--- a/src/test/scala/com/ironcorelabs/davenport/MemConnectionSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/MemConnectionSpec.scala
@@ -12,7 +12,7 @@ import org.typelevel.scalatest._
 import DisjunctionValues._
 import scala.language.postfixOps
 import DB._
-import DB.batch._
+import DB.Batch._
 
 class MemConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll with DisjunctionMatchers with OptionValues with AsyncAssertions {
   "MemConnection" should {
@@ -145,12 +145,12 @@ class MemConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
     //
 
     "be happy doing initial batch import" in {
-      val (map, res) = MemConnection.runProcess(batchCreateDocs(tenrows)).value
+      val (map, res) = MemConnection.runProcess(createDocs(tenrows)).value
       res.toList.separate._2.length should ===(tenrows.length)
     }
     "return errors batch importing the same items again" in {
-      val (data, result) = MemConnection.runProcess(batchCreateDocs(tenrows)).value
-      val p = batchCreateDocs(tenrows ++ fiveMoreRows)
+      val (data, result) = MemConnection.runProcess(createDocs(tenrows)).value
+      val p = createDocs(tenrows ++ fiveMoreRows)
       val (map, res) = MemConnection.runProcess(p, data).value
       res.length should ===(tenrows.length + fiveMoreRows.length)
       val (lefts, rights) = res.toList.separate
@@ -158,13 +158,13 @@ class MemConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
       rights.length should ===(fiveMoreRows.length)
     }
     "fail after on first error if we pass in a halting function" in {
-      val (data, res1) = MemConnection.runProcess(batchCreateDocs(tenrows)).value
-      val (_, res) = MemConnection.runProcess(batchCreateDocs(tenrows).takeWhile(_.isRight), data).value
+      val (data, res1) = MemConnection.runProcess(createDocs(tenrows)).value
+      val (_, res) = MemConnection.runProcess(createDocs(tenrows).takeWhile(_.isRight), data).value
       res.length should ===(0)
     }
 
     "don't try and insert first 5 and return 5 errors" in {
-      val (data, res) = MemConnection.runProcess(batchCreateDocs(tenrows.drop(5))).value
+      val (data, res) = MemConnection.runProcess(createDocs(tenrows.drop(5))).value
       res.length should ===(5)
       res.toList.separate._2.length should ===(5)
     }

--- a/src/test/scala/com/ironcorelabs/davenport/MemConnectionSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/MemConnectionSpec.scala
@@ -81,11 +81,15 @@ class MemConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
     }
     "fail updating a doc that doesn't exist" in {
       val testUpdate = updateDoc(k, newvalue, hv)
-      MemConnection.run(testUpdate)._2 should be(left)
+      val (data, res) = MemConnection.run(testUpdate)
+      data should ===(emptyData)
+      res should be(left)
     }
     "fail updating a doc when using incorrect hashver" in {
       val testUpdate = updateDoc(k, newvalue, HashVer(0))
-      MemConnection.run(testUpdate, seedData)._2 should be(left)
+      val (data, res) = MemConnection.run(testUpdate, seedData)
+      data should ===(seedData)
+      res should be(left)
     }
     "remove a key that exists" in {
       val testRemove = removeKey(k)
@@ -94,7 +98,9 @@ class MemConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
     }
     "fail removing a key that doesn't exist" in {
       val testRemove = removeKey(k)
-      MemConnection.run(testRemove)._2 should be(left)
+      val (data, res) = MemConnection.run(testRemove)
+      data should ===(emptyData)
+      res should be(left)
     }
     "modify map" in {
       val testModify = modifyDoc(k, j => newvalue)
@@ -103,7 +109,9 @@ class MemConnectionSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
     }
     "modify map fails if key is not in db" in {
       val testModify = modifyDoc(k, j => newvalue)
-      MemConnection.run(testModify)._2 should be(left)
+      val (data, res) = MemConnection.run(testModify)
+      data should ===(emptyData)
+      res should be(left)
     }
 
     //


### PR DESCRIPTION
I've changed the batchImport api to use Scalaz.stream instead of iterator. Because of this I had to change MemConnection to use StateT so that we had a `Catchable` instance for the type Process is paramaterized over. I ignored errors thrown into it because the NT from DBOP ~> State will never throw. I could maybe do better there, but I think this is a step in the right direction.

I'll be updating with a tut example page shortly.