### PR TITLE
Query based on id of the document.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,11 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % ScalazVersion, // for type awesomeness
   "org.scalaz" %% "scalaz-concurrent" % ScalazVersion, // for type awesomeness
-  "com.couchbase.client" % "java-client" % "2.1.4", // interacting with couch
+  "com.couchbase.client" % "java-client" % "2.2.0", // interacting with couch
   "io.reactivex" %% "rxscala" % "0.25.0", // to better work with the couchbase java client
   "io.argonaut" %% "argonaut" % "6.1", // json (de)serialization scalaz style
-  "org.scalaz.stream" %% "scalaz-stream" % "0.7.2a"
+  "org.scalaz.stream" %% "scalaz-stream" % "0.7.2a",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"
 )
 
 // Test
@@ -29,7 +30,7 @@ libraryDependencies ++= Seq(
   "oncue.knobs" %% "core" % "3.3.3" % "test"
 )
 
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
 
 // Code coverage checks
 coverageMinimum := 70

--- a/src/main/scala/com/ironcorelabs/davenport/datastore/CouchDatastore.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/datastore/CouchDatastore.scala
@@ -111,11 +111,11 @@ final object CouchDatastore extends com.typesafe.scalalogging.StrictLogging {
         typ <- Option(meta.getString(TypeString))
       } yield (key, cas, typ)
 
-    private def getJsonString(couchbaseObject: Any, fieldType: String): Option[String] = fieldType match {
+    private def getJsonString[A](couchbaseObject:A, fieldType: String): Option[String] = fieldType match {
       case "json" =>
         couchbaseObject match {
           //We have to surround the string with " to make it valid Json again.
-          case v: String => ("\"" + v.toString + "\"").some
+          case v: String => ("\"" + v + "\"").some
           case v: Integer => v.toString.some
           case v: Long => v.toString.some
           case v: Double => v.toString.some

--- a/src/main/scala/com/ironcorelabs/davenport/datastore/CouchDatastore.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/datastore/CouchDatastore.scala
@@ -8,18 +8,21 @@ package datastore
 
 import scalaz.{ \/, Kleisli, ~>, Free }
 import scalaz.concurrent.Task
-import scalaz.syntax.std.option._ //for .toRightDisjunction
-import scalaz.syntax.monad._ //For .join
+import scalaz.Scalaz._
 import db._
+import scalaz.stream.Process
 
 // Couchbase
 import com.couchbase.client.java.{ Bucket, AsyncBucket }
 import com.couchbase.client.java.document.{ AbstractDocument, JsonLongDocument, RawJsonDocument }
 import com.couchbase.client.java.error._
+import com.couchbase.client.java.query.N1qlQuery
+import com.couchbase.client.java.document.json._ //Need all the Json types
 
 // RxScala (Observables) used in Couchbase client lib async calls
 import rx.lang.scala.Observable
 import rx.lang.scala.JavaConversions._
+import scalaz.stream.async
 
 /**
  * Create a CouchDatastore which operates on the bucket provided. Note that the primary way this should be used is through
@@ -43,8 +46,16 @@ final case class CouchDatastore(bucket: Task[Bucket]) extends Datastore {
  * For details about how this translation is done, look at couchRunner which routes each DBOp to its couchbase
  * counterpart.
  */
-final object CouchDatastore {
+final object CouchDatastore extends com.typesafe.scalalogging.StrictLogging {
   type CouchK[A] = Kleisli[Task, Bucket, A]
+  private[this] final val BoundedQueueSize = 10000
+
+  private[this] final val MetaString = "meta"
+  private[this] final val RecordString = "record"
+  //These are constants that match couchbase fields
+  private[this] final val IdString = "id"
+  private[this] final val CasString = "cas"
+  private[this] final val TypeString = "type"
 
   /**
    * Interpret the program into a Kleisli that will take a Bucket as its argument. Useful if you want to do
@@ -71,6 +82,69 @@ final object CouchDatastore {
       case IncrementCounter(k: Key, delta: Long) => incrementCounter(k, delta)
       case RemoveKey(k: Key) => removeKey(k)
       case UpdateDoc(k: Key, v: RawJsonString, cv: CommitVersion) => updateDoc(k, v, cv)
+      case ScanKeys(op: Comparison, value: String) => Kleisli.kleisli(scanKeys(op, value).map(_.right.point[Task]))
+    }
+
+    private def scanField(field: String, op: Comparison, value: String): Bucket => Process[Task, DBValue] = { bucket: Bucket =>
+      val query = createStatement(bucket.name, field, op, value)
+      observableToProcess(bucket.async.query(query)).flatMap(result => observableToProcess(result.rows)).flatMap { row =>
+        logger.debug("Recieved row" + row.value.toString)
+        val maybeMetadata = Option(row.value.getObject(MetaString)).flatMap(extractFromMeta(_))
+        val (keyString, cas, typ) = maybeMetadata.getOrElse(throw new Exception(s"${row.value.toString} was screwed up in a way we couldn't understand at all."))
+        val maybeStringifiedValue = getJsonString(row.value.get(RecordString), typ)
+        maybeStringifiedValue.map { result =>
+          Process.emit(DBDocument[RawJsonString](Key(keyString), CommitVersion(cas), RawJsonString(result)))
+        }.getOrElse(Process.empty) //Flatten things we can't deal with out of existence.
+      }
+    }
+
+    /**
+     * Extract the key, cas and type of record from the meta Json
+     */
+    private def extractFromMeta(meta: JsonObject): Option[(String, Long, String)] =
+      for {
+        key <- Option(meta.getString(IdString))
+        cas <- Option(meta.getLong(CasString))
+        typ <- Option(meta.getString(TypeString))
+      } yield (key, cas, typ)
+
+    private def getJsonString(couchbaseObject: Any, fieldType: String): Option[String] = fieldType match {
+      case "json" =>
+        couchbaseObject match {
+          case v: String => v.toString.some
+          case v: Integer => v.toString.some
+          case v: Long => v.toString.some
+          case v: Double => v.toString.some
+          case v: Boolean => v.toString.some
+          case v: JsonObject => v.toString.some
+          case v: JsonArray => v.toString.some
+          case x => //This is a dev exception. If this happens you need to handle the case.
+            throw new Exception(s"All Json types should be covered, but found '$x'")
+        }
+      case typ =>
+        logger.warn(s"Was asked to decode json, but found '$typ'.")
+        None
+    }
+
+    private def scanKeys(op: Comparison, value: String): Bucket => Process[Task, DBValue] =
+      scanField(s"meta($RecordString).id", op, value)
+
+    private def opToFunc(op: Comparison)(name: String): String = {
+      val string = op match {
+        case EQ => "="
+        case GT => ">"
+        case LT => "<"
+        case LTE => "<="
+        case GTE => ">="
+      }
+      name + string + "$1"
+    }
+
+    private def createStatement(bucketName: String, field: String, op: Comparison, value: String): N1qlQuery = {
+      import scala.collection.JavaConverters._
+      val queryString = s"SELECT $RecordString, meta($RecordString) as $MetaString FROM $bucketName $RecordString where ${opToFunc(op)(field)};"
+      logger.debug(s"Query created: '$queryString' with $value")
+      N1qlQuery.parameterized(queryString, JsonArray.from(List(value).asJava))
     }
 
     /*
@@ -113,17 +187,17 @@ final object CouchDatastore {
       couchOpToA(fetchOp)(doc => Long2long(doc.content)).map(_.leftMap(throwableToDBError(k, _)))
     }
 
-    // These lines are too long for scalastyle, but can't find a way to stop
-    // scalastyle from pasting them back together wherever I split them, so
-    // they are getting the big ignore hammer.
-    private def couchOpToDBValue(k: Key)(fetchOp: AsyncBucket => Observable[RawJsonDocument]): CouchK[DBError \/ DBValue] = // scalastyle:ignore
-      couchOpToA(fetchOp)(doc => DBDocument(k, CommitVersion(doc.cas), RawJsonString(doc.content))).
-        map(_.leftMap(throwableToDBError(k, _)))
+    private def couchOpToDBValue(k: Key)(
+      fetchOp: AsyncBucket => Observable[RawJsonDocument]
+    ): CouchK[DBError \/ DBValue] = {
+      couchOpToA(fetchOp) { doc => DBDocument(k, CommitVersion(doc.cas), RawJsonString(doc.content)) }
+        .map(_.leftMap(throwableToDBError(k, _)))
+    }
 
-    private def couchOpToA[A, B](
-      fetchOp: AsyncBucket => Observable[AbstractDocument[B]]
-    )(f: AbstractDocument[B] => A): Kleisli[Task, Bucket, Throwable \/ A] = Kleisli.kleisli { bucket: Bucket =>
-      obs2Task(fetchOp(bucket.async)).map(_.map(f))
+    private def couchOpToA[A, B](fetchOp: AsyncBucket => Observable[AbstractDocument[B]])(f: AbstractDocument[B] => A): CouchK[Throwable \/ A] = { // scalastyle:ignore
+      Kleisli.kleisli { bucket: Bucket =>
+        obs2Task(fetchOp(bucket.async)).map(_.map(f))
+      }
     }
 
     private def throwableToDBError(key: Key, t: Throwable): DBError = t match {
@@ -140,6 +214,19 @@ final object CouchDatastore {
       //We want to `attempt` to gather any error that might have happened in the task
       //and then we need to flatten the nested disjunctions.
       headOptionTask.map(_.toRightDisjunction(new DocumentDoesNotExistException())).attempt.map(_.join)
+    }
+
+    private def observableToProcess[A](o: Observable[A]): Process[Task, A] = {
+      val queue = async.boundedQueue[A](BoundedQueueSize, true)
+      o.subscribe(
+        n => queue.enqueueOne(n).run,
+        { ex =>
+          logger.error("Error retrieving value from couchbase.", ex)
+          queue.kill.run
+        },
+        () => queue.close.run
+      )
+      queue.dequeue
     }
   }
 }

--- a/src/main/scala/com/ironcorelabs/davenport/datastore/MemDatastore.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/datastore/MemDatastore.scala
@@ -134,8 +134,8 @@ object MemDatastore {
         }
         case GetCounter(k) => getCounter(k)
         case IncrementCounter(k, delta) => incrementCounter(k, delta)
-        case ScanKeys(comparison, value) => state { map =>
-          map -> scalaz.stream.Process.emitAll(findRecords(comparison, value)(map)).right
+        case ScanKeys(comparison, value, limit, offset, _) => state { map =>
+          map -> findRecords(comparison, value)(map).drop(offset).take(limit).sortBy(_.key).right
         }
       }
     }

--- a/src/main/scala/com/ironcorelabs/davenport/db/Comparison.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/Comparison.scala
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2015 IronCore Labs
+//
+package com.ironcorelabs.davenport.db
+
+sealed trait Comparison
+
+case object EQ extends Comparison
+case object GT extends Comparison
+case object LT extends Comparison
+case object LTE extends Comparison
+case object GTE extends Comparison

--- a/src/main/scala/com/ironcorelabs/davenport/db/DBOp.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/DBOp.scala
@@ -4,6 +4,8 @@
 package com.ironcorelabs.davenport.db
 
 import scalaz.\/
+import scalaz.concurrent.Task
+import scalaz.stream.Process
 
 /** Any database operation must be represented by a `DBOp` */
 sealed trait DBOp[A]
@@ -13,3 +15,4 @@ final case class UpdateDoc(key: Key, doc: RawJsonString, commitVersion: CommitVe
 final case class RemoveKey(key: Key) extends DBOp[DBError \/ Unit]
 final case class GetCounter(key: Key) extends DBOp[DBError \/ Long]
 final case class IncrementCounter(key: Key, delta: Long = 1) extends DBOp[DBError \/ Long]
+final case class ScanKeys(op: Comparison, value: String) extends DBOp[DBError \/ Process[Task, DBValue]]

--- a/src/main/scala/com/ironcorelabs/davenport/db/DBOp.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/DBOp.scala
@@ -4,7 +4,6 @@
 package com.ironcorelabs.davenport.db
 
 import scalaz.\/
-import scalaz.concurrent.Task
 
 /** Any database operation must be represented by a `DBOp` */
 sealed trait DBOp[A]

--- a/src/main/scala/com/ironcorelabs/davenport/db/DBOp.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/DBOp.scala
@@ -5,7 +5,6 @@ package com.ironcorelabs.davenport.db
 
 import scalaz.\/
 import scalaz.concurrent.Task
-import scalaz.stream.Process
 
 /** Any database operation must be represented by a `DBOp` */
 sealed trait DBOp[A]
@@ -15,4 +14,5 @@ final case class UpdateDoc(key: Key, doc: RawJsonString, commitVersion: CommitVe
 final case class RemoveKey(key: Key) extends DBOp[DBError \/ Unit]
 final case class GetCounter(key: Key) extends DBOp[DBError \/ Long]
 final case class IncrementCounter(key: Key, delta: Long = 1) extends DBOp[DBError \/ Long]
-final case class ScanKeys(op: Comparison, value: String) extends DBOp[DBError \/ Process[Task, DBValue]]
+//Constuctor hidden for safety. Limit and offset have to >=0
+final case class ScanKeys private[db] (op: Comparison, value: String, limit: Int, offset: Int, consistency: ScanConsistency) extends DBOp[DBError \/ List[DBValue]]

--- a/src/main/scala/com/ironcorelabs/davenport/db/ScanConsistency.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/ScanConsistency.scala
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2015 IronCore Labs
+//
+package com.ironcorelabs.davenport.db
+
+sealed trait ScanConsistency
+
+/**
+ * If passed to [ScanKeys] possibly stale data will be returned, but the query can start immediately.
+ */
+case object AllowStale extends ScanConsistency
+
+/**
+ * If you need to guarantee the most up to date data from the index. The query will wait until all writes have been
+ * completed and the index is caught up.
+ */
+case object EnsureConsistency extends ScanConsistency

--- a/src/main/scala/com/ironcorelabs/davenport/db/Wrappers.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/Wrappers.scala
@@ -3,8 +3,15 @@
 //
 package com.ironcorelabs.davenport.db
 
+import scalaz.Order
+import scalaz.std.string._
+
 /** Just a string. This is used for type safety. */
 final case class Key(value: String) extends AnyVal
+
+object Key {
+  implicit final val OrderInstance = scalaz.Order[String].contramap[Key](_.value)
+}
 
 /** Just a string. This is used for type safety. */
 final case class RawJsonString(value: String) extends AnyVal

--- a/src/main/scala/com/ironcorelabs/davenport/db/Wrappers.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/Wrappers.scala
@@ -10,7 +10,8 @@ import scalaz.std.string._
 final case class Key(value: String) extends AnyVal
 
 object Key {
-  implicit final val OrderInstance = scalaz.Order[String].contramap[Key](_.value)
+  implicit final val OrderInstance: Order[Key] = Order[String].contramap[Key](_.value)
+  implicit final val OrderingInstance: scala.math.Ordering[Key] = OrderInstance.toScalaOrdering
 }
 
 /** Just a string. This is used for type safety. */

--- a/src/main/scala/com/ironcorelabs/davenport/db/package.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/package.scala
@@ -49,6 +49,8 @@ package object db {
   def incrementCounter(k: Key, delta: Long = 1): DBProg[Long] =
     liftToFreeEitherT(IncrementCounter(k, delta))
 
+  def scanKeys(op: Comparison, value: String): DBProg[scalaz.stream.Process[Task, DBValue]] =
+    liftToFreeEitherT(ScanKeys(op, value))
   //
   // Common combinators for DBProg
   //

--- a/src/main/scala/com/ironcorelabs/davenport/db/package.scala
+++ b/src/main/scala/com/ironcorelabs/davenport/db/package.scala
@@ -49,8 +49,8 @@ package object db {
   def incrementCounter(k: Key, delta: Long = 1): DBProg[Long] =
     liftToFreeEitherT(IncrementCounter(k, delta))
 
-  def scanKeys(op: Comparison, value: String): DBProg[scalaz.stream.Process[Task, DBValue]] =
-    liftToFreeEitherT(ScanKeys(op, value))
+  def scanKeys(op: Comparison, value: String, limit: Int, offset: Int, consistency: ScanConsistency): DBProg[List[DBValue]] =
+    liftToFreeEitherT(ScanKeys(op, value, limit, offset, consistency))
   //
   // Common combinators for DBProg
   //

--- a/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
@@ -15,7 +15,6 @@ class CouchConnectionSpec extends TestBase with KnobsConfiguration {
 
   val davenportConfig = knobsConfiguration.run
   override def beforeAll() = {
-
     connection = CouchConnection(davenportConfig)
     ()
   }

--- a/src/test/scala/com/ironcorelabs/davenport/datastore/DatastoreSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/datastore/DatastoreSpec.scala
@@ -218,7 +218,7 @@ abstract class DatastoreSpec extends TestBase {
     "Scan keys GTE" in {
       val datastore = emptyDatastore
       import argonaut._, Argonaut._
-      import DB._
+      import db._
       import syntax._
       case class Test(string: String, enabled: Boolean)
       implicit def codec: CodecJson[Test] = CodecJson.derive[Test]
@@ -231,7 +231,7 @@ abstract class DatastoreSpec extends TestBase {
       } yield ()
       creates.execute(datastore).attemptRun.value
       Thread.sleep(2000L)
-      val p = scanKeys(db.GTE, k2.value).execute(datastore).attemptRun.value.value
+      val p = scanKeys(GTE, k2.value).execute(datastore).attemptRun.value.value
       val result: IndexedSeq[DBValue] = p.runLog.attemptRun.value
       result should have length (1)
       result.headOption.value.key shouldBe k2


### PR DESCRIPTION
This is just a PR to gather feedback on the idea of scanning on the `id` of each document:

- GT, GTE, EQ, LTE, LT comparisons on the `id` of the document
- support limit and offset on the scans
- support different consistency constraints on scans.