### PR TITLE
Upgrade scalaz-stream, remove knobs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-val ScalazVersion = "7.1.5"
+val ScalazVersion = "7.1.9"
 
 // crossScalaVersions := Seq("2.10.4")
 
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "com.couchbase.client" % "core-io" % "1.2.3",
   "io.reactivex" %% "rxscala" % "0.25.0", // to better work with the couchbase java client
   "io.argonaut" %% "argonaut" % "6.1", // json (de)serialization scalaz style
-  "org.scalaz.stream" %% "scalaz-stream" % "0.7.2a",
+  "org.scalaz.stream" %% "scalaz-stream" % "0.8.4",
   "org.scodec" %% "scodec-bits" % "1.1.1"
 )
 
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "scalaz-scalatest" % "0.2.2" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",
   "org.scalaz" %% "scalaz-scalacheck-binding" % ScalazVersion,
-  "oncue.knobs" %% "core" % "3.3.3" % "test"
+  "com.github.melrief" %% "pureconfig" % "0.2.2" % "test"
 )
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.9
-scala.version=2.11.7
+sbt.version=0.13.12
+scala.version=2.11.8

--- a/src/test/resources/davenport-test.cfg
+++ b/src/test/resources/davenport-test.cfg
@@ -1,4 +1,7 @@
-cdb {
-  host = "127.0.0.1"
+{
+  hosts = "127.0.0.1"
+  ioPoolSize = 4
+  computationPoolSize = 4
+  kvEndpoints = 1
 }
 

--- a/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/CouchConnectionSpec.scala
@@ -13,7 +13,6 @@ import scala.concurrent.duration._
 class CouchConnectionSpec extends TestBase with KnobsConfiguration {
   var connection: CouchConnection = null
 
-  val davenportConfig = knobsConfiguration.run
   override def beforeAll() = {
 
     connection = CouchConnection(davenportConfig)

--- a/src/test/scala/com/ironcorelabs/davenport/datastore/CouchDatastoreSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/datastore/CouchDatastoreSpec.scala
@@ -16,7 +16,6 @@ import org.scalatest.BeforeAndAfter
 @RequiresCouch
 class CouchDatastoreSpec extends DatastoreSpec with BeforeAndAfter with KnobsConfiguration {
   def datastoreName: String = "CouchDatastoreBasicTests"
-  val davenportConfig = knobsConfiguration.run
   var connection: CouchConnection = null
   def emptyDatastore: Datastore = connection.openDatastore(BucketNameAndPassword("default", None))
 

--- a/src/test/scala/com/ironcorelabs/davenport/datastore/DatastoreSpec.scala
+++ b/src/test/scala/com/ironcorelabs/davenport/datastore/DatastoreSpec.scala
@@ -158,7 +158,7 @@ abstract class DatastoreSpec extends TestBase {
 
     "show Process[Task] coming together with Process[DBOps]" in {
       val dataStream = Process.eval(Task.now(k -> v))
-      val task: Task[IndexedSeq[DBError \/ RawJsonString]] = dataStream.flatMap {
+      val task: Task[Vector[DBError \/ RawJsonString]] = dataStream.flatMap {
         case (key, value) =>
           createDoc(key, value).map(_.data).process.execute(emptyDatastore)
       }.runLog


### PR DESCRIPTION
- Upgrade scalaz stream to latest to be in sync with scodec bits #47 
- Remove knobs. They don't have a scalaz 7.1 scalaz-stream 0.8.x and it was only for testing anyways.
- Upgrade to latest scala and scalaz 7.1.x